### PR TITLE
Replace Depfu with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    groups:
+      routine-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    groups:
+      routine-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
## What changed

- add grouped monthly Dependabot updates for npm and GitHub Actions
- wait three days before routine version updates
- cap the number of open update pull requests
- remove obsolete Depfu branding where present

## Why

Depfu still has GitHub App access to this repository even though its update activity has been dormant for years. This replaces that installation with a low-noise Dependabot configuration before Depfu access is revoked account-wide.

## Validation

- Dependabot YAML parses successfully
- clean npm install
- full test suite
- git diff --check